### PR TITLE
Fix chart line colors to match game names

### DIFF
--- a/src/components/Game/GameChart/GameChart.tsx
+++ b/src/components/Game/GameChart/GameChart.tsx
@@ -173,6 +173,8 @@ export const GameChart: React.FC = () => {
         <div className="h-full flex flex-col">
           {visibleGamesData.map(({name, rank, link, rankDifference}, index) => {
             // Handle the fallback logic: NaN becomes undefined, otherwise use the value
+            // Find the color index from allGameNames to match the chart line color
+            const colorIndex = allGameNames.indexOf(name);
             return (
               <div
                 key={index}
@@ -180,7 +182,7 @@ export const GameChart: React.FC = () => {
                 style={{height: `${rowHeight}px`}}
               >
                 <p
-                  style={{color: `${lineColors[index % lineColors.length]}`}}
+                  style={{color: `${lineColors[colorIndex % lineColors.length]}`}}
                   className="text-lg flex items-center w-full"
                 >
                   <span className="mr-1">{rank}.</span>


### PR DESCRIPTION
The colors were alternating based on the left side of the plot (using visibleGamesData index), but they should alternate based on the right side to match the game names. Now using allGameNames index for both chart lines and game name colors to ensure they match correctly.