### PR TITLE
Fix game aggregation to use ID instead of name

### DIFF
--- a/src/components/Game/GameChart/GameChart.tsx
+++ b/src/components/Game/GameChart/GameChart.tsx
@@ -122,20 +122,23 @@ export const GameChart: React.FC = () => {
       new Date(entry.day).toLocaleDateString()
     );
 
-    // Create a map from game name to its position in visibleGamesData (right side)
+    // Create a map from game ID to its position in visibleGamesData (right side)
     // This ensures colors match the order on the right side
     const gameColorIndexMap = new Map(
-      visibleGamesData.map((game, index) => [game.name, index])
+      visibleGamesData.map((game, index) => [game.id.toString(), index])
     );
 
-    const datasets = allGameNames.map((gameName) => {
+    const datasets = allGameNames.map((gameId) => {
       // Get the color index from the game's position in visibleGamesData
-      const colorIndex = gameColorIndexMap.get(gameName) ?? 0;
+      const colorIndex = gameColorIndexMap.get(gameId) ?? 0;
       const color = lineColors[colorIndex % lineColors.length];
+
+      // Find the game name for the label
+      const gameName = visibleGamesData.find(g => g.id.toString() === gameId)?.name ?? gameId;
 
       return {
         label: gameName,
-        data: dataset.map((entry) => entry[gameName] as number | undefined),
+        data: dataset.map((entry) => entry[gameId] as number | undefined),
         borderColor: color,
         backgroundColor: color,
         tension: 0.1,

--- a/src/components/Game/useGameData.ts
+++ b/src/components/Game/useGameData.ts
@@ -105,6 +105,7 @@ async function fetchGameData(
 
 interface GameData {
     rank: number;
+    id: number;
     name: string;
     link: string;
 }

--- a/src/components/Game/useGameDataStore.ts
+++ b/src/components/Game/useGameDataStore.ts
@@ -21,13 +21,13 @@ export const useGameDataStore = create<{
   setDailyGameDataAndDataset: (dailyGameData: DailyGameData[]) => {
     // Process data before setting the state
     const dataset = dailyGameData.map(({day, data}) =>
-      data.reduce((acc, {name, rank}) => ({
+      data.reduce((acc, {id, rank}) => ({
         ...acc,
-        [name]: rank
+        [id]: rank
       }), {day} as GameDayRanks)
     ).filter(dayRanks => Object.keys(dayRanks).length > 2);
 
-    // Compute the allGameNames just once here
+    // Compute the allGameNames (now game IDs) just once here
     const allGameNames = Array.from(new Set(
       dataset.flatMap(dayRanks =>
         Object.keys(dayRanks).filter(key => key !== 'day')
@@ -54,8 +54,8 @@ export const useGameDataStore = create<{
     const lastDayArray = lastDayData.data
       .filter(({rank}) => rank <= topRanksShowed)
       .map((game) => {
-        const firstDayRank = firstVisibleDay[game.name] as number | undefined;
-        const lastDayRank = lastVisibleDay[game.name] as number;
+        const firstDayRank = firstVisibleDay[game.id] as number | undefined;
+        const lastDayRank = lastVisibleDay[game.id] as number;
         const rankDifference = (firstDayRank !== undefined && !isNaN(firstDayRank))
           ? firstDayRank - lastDayRank
           : undefined;
@@ -69,7 +69,7 @@ export const useGameDataStore = create<{
 
     return {
       visibleGamesData: lastDayArray,
-      visibleGameNames: lastDayArray.map(game => game.name)
+      visibleGameNames: lastDayArray.map(game => game.id.toString())
     };
   })
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 // global types
 export type GameData = {
     rank: number;
+    id: number;
     name: string;
     link: string;
 }
@@ -17,5 +18,5 @@ export type SupplementedGameData = GameData & { // TBD
 
 export type GameDayRanks = {
     day: string;
-    [gameName: string]: number | string;
+    [gameId: string]: number | string;
 }


### PR DESCRIPTION
Changed the aggregation logic to use game IDs as keys instead of game names. This prevents issues when games change their names over time, which previously caused data to appear fragmented.

Changes:
- Added id field to GameData type
- Updated GameDayRanks to use gameId as keys instead of gameName
- Modified aggregation logic in useGameDataStore to use game.id
- Updated GameChart to map games by ID while displaying names
- CSV parser now handles the new id field from updated CSV format